### PR TITLE
Add support for categorical values and pandas DataFrame as input

### DIFF
--- a/libs/ccc/coef/__init__.py
+++ b/libs/ccc/coef/__init__.py
@@ -1,0 +1,1 @@
+from ccc.coef.impl import *

--- a/libs/ccc/coef/__init__.py
+++ b/libs/ccc/coef/__init__.py
@@ -1,1 +1,1 @@
-from ccc.coef.impl import *
+from ccc.coef.impl import *  # noqa: F403, F401

--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -382,13 +382,13 @@ def ccc(
             (a pair of objects), then max_parts[0] and max_parts[1] have the
             partition indexes in parts, respectively: parts[0][max_parts[0]]
             points to the partition for x, and parts[1][max_parts[1]] points to
-            the partition for y.
-            TODO: mention here that "invalid" or "missing" partitions have all -1 values
-              for example, for categorical values only the first one makes sense
+            the partition for y. Values could be negative in case
+            singleton cases were found (-1; usually because input data has all the same
+            value) or for categorical features (-2).
     """
     n_objects = None
     n_features = None
-    # this is a boolean array with 1 if the feature is numerical and 0 otherwise
+    # this is a boolean array of size n_features with True if the feature is numerical and False otherwise
     X_numerical_type = None
     if x.ndim == 1 and (y is not None and y.ndim == 1):
         # both x and y are 1d arrays

--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -133,11 +133,12 @@ def get_parts(
             k = range_n_clusters[idx]
             parts[idx] = run_quantile_clustering(data, k)
 
-        # remove singletons
+        # remove singletons by putting a -2 as values
         partitions_ks = np.array([len(np.unique(p)) for p in parts])
-        parts[partitions_ks == 1, :] = -1
+        parts[partitions_ks == 1, :] = -2
     else:
         # if the data is categorical, then the encoded feature is already the partition
+        # only the first partition is filled, the rest will be -1 (missing)
         parts[0] = data.astype(np.int16)
 
     return parts
@@ -509,8 +510,10 @@ def ccc(
                 obji_parts, objj_parts = parts[i], parts[j]
 
                 # compute ari only if partitions are not marked as "missing"
-                # (negative values)
-                if obji_parts[0, 0] < 0 or objj_parts[0, 0] < 0:
+                # (negative values), which is assigned when partitions have
+                # one cluster (usually when all data in the feature has the same
+                # value).
+                if obji_parts[0, 0] == -2 or objj_parts[0, 0] == -2:
                     continue
 
                 # compare all partitions of one object to the all the partitions

--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -239,21 +239,6 @@ def get_coords_from_index(n_obj: int, idx: int) -> tuple[int]:
     return int(x), int(y)
 
 
-def to_numpy(x):
-    """
-    Converts x into a numpy array. It is used to convert pandas Series and
-    DataFrames into numpy objects.
-    """
-    if x is None:
-        return x
-
-    func = getattr(x, "to_numpy", None)
-    if not callable(func):
-        return x
-
-    return x.to_numpy()
-
-
 def get_chunks(
     iterable: Union[int, Iterable], n_threads: int, ratio: float = 1
 ) -> Iterable[Iterable[int]]:
@@ -403,8 +388,6 @@ def ccc(
 
         X = np.zeros((n_features, n_objects))
         X_numerical_type = np.full((n_features,), True, dtype=bool)
-        # for idx in range(n_features):
-        #     feature_data, feature_is_numerical = get_feature_type_and_encode()
 
         X[0, :], X_numerical_type[0] = get_feature_type_and_encode(x)
         X[1, :], X_numerical_type[1] = get_feature_type_and_encode(y)

--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -108,7 +108,7 @@ def get_range_n_clusters(
 
 @njit(cache=True, nogil=True)
 def get_parts(
-    data: NDArray, range_n_clusters: tuple[int], data_is_numerical=True
+    data: NDArray, range_n_clusters: tuple[int], data_is_numerical: bool = True
 ) -> NDArray[np.int16]:
     """
     Given a 1d data array, it computes a partition for each k value in the given
@@ -120,11 +120,17 @@ def get_parts(
     Args:
         data: a 1d data vector. It is assumed that there are no nans.
         range_n_clusters: a tuple with the number of clusters.
-        data_type: "numerical" or "categorical"
+        data_is_numerical: indicates whether data is numerical (True) or categorical (False)
 
     Returns:
         A numpy array with shape (number of clusters, data rows) with
         partitions of data.
+
+        Partitions could have negative values in some scenarios, with different
+        meanings: -1 is used for categorical data, where only one partition is generated
+        and the rest (-1) are marked as "empty". -2 is used when singletons have been
+        detected (partitions with one cluster), usually because of problems with the
+        input data (it has all the same values, for example).
     """
     parts = np.zeros((len(range_n_clusters), data.shape[0]), dtype=np.int16) - 1
 

--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -295,12 +295,20 @@ def get_chunks(
     return res
 
 
-def get_feature_type_and_encode(feature_data):
+def get_feature_type_and_encode(feature_data: NDArray) -> tuple[NDArray, bool]:
     """
     Given the data of one feature as a 1d numpy array (it could also be a pandas.Series),
     it returns the same data if it is numerical (float, signed or unsigned integer) or an
     encoded version if it is categorical (each category value has a unique integer starting from
     zero).
+
+    Args:
+        feature_data: a 1d array with data.
+
+    Returns:
+        A tuple with two elements:
+          1. the feature data: same as input if numerical, encoded version if not numerical.
+          2. A boolean indicating whether the feature data is numerical or not.
     """
     data_type_is_numerical = feature_data.dtype.kind in ("f", "i", "u")
     if data_type_is_numerical:

--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -16,7 +16,7 @@ from ccc.utils import chunker
 
 
 @njit(cache=True, nogil=True)
-def _get_perc_from_k(k: int) -> list[float]:
+def get_perc_from_k(k: int) -> list[float]:
     """
     It returns the percentiles (from 0.0 to 1.0) that separate the data into k
     clusters. For example, if k=2, it returns [0.5]; if k=4, it returns [0.25,
@@ -53,7 +53,7 @@ def run_quantile_clustering(data: NDArray, k: int) -> NDArray[np.int16]:
     data_rank = rank(data, data_sorted)
     data_perc = data_rank / len(data)
 
-    percentiles = [0.0] + _get_perc_from_k(k) + [1.0]
+    percentiles = [0.0] + get_perc_from_k(k) + [1.0]
 
     cut_points = np.searchsorted(data_perc[data_sorted], percentiles, side="right")
 
@@ -71,7 +71,7 @@ def run_quantile_clustering(data: NDArray, k: int) -> NDArray[np.int16]:
 
 
 @njit(cache=True, nogil=True)
-def _get_range_n_clusters(
+def get_range_n_clusters(
     n_features: int, internal_n_clusters: Iterable[int] = None
 ) -> NDArray[np.uint8]:
     """
@@ -107,7 +107,7 @@ def _get_range_n_clusters(
 
 
 @njit(cache=True, nogil=True)
-def _get_parts(
+def get_parts(
     data: NDArray, range_n_clusters: tuple[int], data_is_numerical=True
 ) -> NDArray[np.int16]:
     """
@@ -429,7 +429,7 @@ def ccc(
         internal_n_clusters = _tmp_list
 
     # get matrix of partitions for each object pair
-    range_n_clusters = _get_range_n_clusters(n_objects, internal_n_clusters)
+    range_n_clusters = get_range_n_clusters(n_objects, internal_n_clusters)
 
     if range_n_clusters.shape[0] == 0:
         raise ValueError(f"Data has too few objects: {n_objects}")
@@ -455,7 +455,7 @@ def ccc(
 
         def compute_parts(idxs):
             return np.array(
-                [_get_parts(X[i], range_n_clusters, X_numerical_type[i]) for i in idxs]
+                [get_parts(X[i], range_n_clusters, X_numerical_type[i]) for i in idxs]
             )
 
         for idx, ps in zip(inputs, executor.map(compute_parts, inputs)):

--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -469,7 +469,6 @@ def ccc(
     )
 
     # cm_values stores the CCC coefficients
-    # n = features_list.shape[0]
     n_features_comp = (n_features * (n_features - 1)) // 2
     cm_values = np.full(n_features_comp, np.nan)
 

--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -158,6 +158,10 @@ def cdist_parts_basic(x: NDArray, y: NDArray) -> NDArray[float]:
 
         cdist(x, y, metric=ari)
 
+    Only partitions with positive labels (> 0) are compared. This means that
+    partitions marked as "singleton" or "empty" (categorical data) are not
+    compared. This has the effect of leaving an ARI of 0.0 (zero).
+
     Args:
         x: a 2d array with m_x clustering partitions in rows and n objects in
           columns.
@@ -172,9 +176,14 @@ def cdist_parts_basic(x: NDArray, y: NDArray) -> NDArray[float]:
     res = np.zeros((x.shape[0], y.shape[0]))
 
     for i in range(res.shape[0]):
+        if x[i, 0] < 0:
+            continue
+
         for j in range(res.shape[1]):
-            if x[i, 0] >= 0 and y[j, 0] >= 0:
-                res[i, j] = ari(x[i], y[j])
+            if y[j, 0] < 0:
+                continue
+
+            res[i, j] = ari(x[i], y[j])
 
     return res
 

--- a/libs/ccc/utils/__init__.py
+++ b/libs/ccc/utils/__init__.py
@@ -1,0 +1,1 @@
+from ccc.utils.utility_functions import *

--- a/libs/ccc/utils/__init__.py
+++ b/libs/ccc/utils/__init__.py
@@ -1,1 +1,1 @@
-from ccc.utils.utility_functions import *
+from ccc.utils.utility_functions import *  # noqa: F403, F401

--- a/libs/ccc/utils/utility_functions.py
+++ b/libs/ccc/utils/utility_functions.py
@@ -7,9 +7,12 @@ from pathlib import Path
 from subprocess import run
 
 import numpy as np
-import pandas as pd
 
-from .log import get_logger
+# optional packages to avoid problems with the CCC PyPI package
+try:
+    from ccc.log import get_logger
+except ModuleNotFoundError:
+    pass
 
 PATTERN_SPACE = re.compile(r" +")
 PATTERN_NOT_ALPHANUMERIC = re.compile(r"[^0-9a-zA-Z_]")
@@ -124,7 +127,7 @@ def human_format(num):
     )
 
 
-def get_upper_triag(similarity_matrix: pd.DataFrame, k: int = 1):
+def get_upper_triag(similarity_matrix, k: int = 1):
     """
     It returns the upper triangular matrix of a dataframe representing a
     similarity matrix between n elements.

--- a/libs/ccc/utils/utility_functions.py
+++ b/libs/ccc/utils/utility_functions.py
@@ -10,6 +10,11 @@ import numpy as np
 
 # optional packages to avoid problems with the CCC PyPI package
 try:
+    # the "ccc.log" module is only used by the code that performs the analyses
+    # for the manuscript, but it is not used in the ccc-coef package (PyPI)
+    # although ccc-coef uses some functions in this module (ccc.utils). Since
+    # "ccc.log" is not distributed as part of ccc-coef, I need to check if it is
+    # present and ignore any ModuleNotFoundError
     from ccc.log import get_logger
 except ModuleNotFoundError:
     pass

--- a/tests/test_coef.py
+++ b/tests/test_coef.py
@@ -3,9 +3,10 @@ from random import shuffle
 
 import numpy as np
 import pandas as pd
-import pytest
+from numba.typed import List
 from sklearn.preprocessing import minmax_scale
 from sklearn.metrics import adjusted_rand_score as ari
+import pytest
 
 from ccc.coef import (
     ccc,
@@ -135,35 +136,24 @@ def test_get_range_n_clusters_without_internal_n_clusters():
 
 
 def test_get_range_n_clusters_with_internal_n_clusters_is_list():
-    from numba.typed import List
-
     # 100 features
-    n_clusters_list = List()
-    n_clusters_list.append(2)
-
     range_n_clusters = get_range_n_clusters(
         100,
-        internal_n_clusters=n_clusters_list,
+        internal_n_clusters=List([2]),
     )
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 25 features
-    n_clusters_list = List()
-    n_clusters_list.append(2)
-
     range_n_clusters = get_range_n_clusters(
         25,
-        internal_n_clusters=n_clusters_list,
+        internal_n_clusters=List([2]),
     )
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 25 features
-    n_clusters_list = List()
-    n_clusters_list.extend([2, 3, 4])
-
-    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=n_clusters_list)
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=List([2, 3, 4]))
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 3, 4]))
 
@@ -184,27 +174,27 @@ def test_get_range_n_clusters_with_internal_n_clusters_none():
 
 def test_get_range_n_clusters_with_internal_n_clusters_has_single_int():
     # 100 features
-    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=[2])
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=List([2]))
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 25 features
-    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[3])
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=List([3]))
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([3]))
 
     # 5 features
-    range_n_clusters = get_range_n_clusters(5, internal_n_clusters=[4])
+    range_n_clusters = get_range_n_clusters(5, internal_n_clusters=List([4]))
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([4]))
 
     # 25 features but invalid number of clusters
-    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[1])
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=List([1]))
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 
     # 25 features but invalid number of clusters
-    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[25])
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=List([25]))
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 

--- a/tests/test_coef.py
+++ b/tests/test_coef.py
@@ -135,28 +135,35 @@ def test_get_range_n_clusters_without_internal_n_clusters():
 
 
 def test_get_range_n_clusters_with_internal_n_clusters_is_list():
+    from numba.typed import List
+
     # 100 features
+    n_clusters_list = List()
+    n_clusters_list.append(2)
+
     range_n_clusters = get_range_n_clusters(
         100,
-        internal_n_clusters=[
-            2,
-        ],
+        internal_n_clusters=n_clusters_list,
     )
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 25 features
+    n_clusters_list = List()
+    n_clusters_list.append(2)
+
     range_n_clusters = get_range_n_clusters(
         25,
-        internal_n_clusters=[
-            2,
-        ],
+        internal_n_clusters=n_clusters_list,
     )
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 25 features
-    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[2, 3, 4])
+    n_clusters_list = List()
+    n_clusters_list.extend([2, 3, 4])
+
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=n_clusters_list)
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 3, 4]))
 

--- a/tests/test_coef.py
+++ b/tests/test_coef.py
@@ -9,10 +9,10 @@ from sklearn.metrics import adjusted_rand_score as ari
 
 from ccc.coef import (
     ccc,
-    _get_range_n_clusters,
+    get_range_n_clusters,
     run_quantile_clustering,
-    _get_perc_from_k,
-    _get_parts,
+    get_perc_from_k,
+    get_parts,
     get_coords_from_index,
     cdist_parts_basic,
     cdist_parts_parallel,
@@ -21,15 +21,15 @@ from ccc.coef import (
 
 
 def test_get_perc_from_k_with_k_less_than_two():
-    assert _get_perc_from_k(1) == []
-    assert _get_perc_from_k(0) == []
-    assert _get_perc_from_k(-1) == []
+    assert get_perc_from_k(1) == []
+    assert get_perc_from_k(0) == []
+    assert get_perc_from_k(-1) == []
 
 
 def test_get_perc_from_k():
-    assert _get_perc_from_k(2) == [0.5]
-    assert np.round(_get_perc_from_k(3), 3).tolist() == [0.333, 0.667]
-    assert _get_perc_from_k(4) == [0.25, 0.50, 0.75]
+    assert get_perc_from_k(2) == [0.5]
+    assert np.round(get_perc_from_k(3), 3).tolist() == [0.333, 0.667]
+    assert get_perc_from_k(4) == [0.25, 0.50, 0.75]
 
 
 def test_run_quantile_clustering_with_two_clusters01():
@@ -122,21 +122,21 @@ def test_run_quantile_clustering_with_four_clusters():
 
 def test_get_range_n_clusters_without_internal_n_clusters():
     # 100 features
-    range_n_clusters = _get_range_n_clusters(100)
+    range_n_clusters = get_range_n_clusters(100)
     assert range_n_clusters is not None
     np.testing.assert_array_equal(
         range_n_clusters, np.array([2, 3, 4, 5, 6, 7, 8, 9, 10])
     )
 
     # 25 features
-    range_n_clusters = _get_range_n_clusters(25)
+    range_n_clusters = get_range_n_clusters(25)
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 3, 4, 5]))
 
 
 def test_get_range_n_clusters_with_internal_n_clusters_is_list():
     # 100 features
-    range_n_clusters = _get_range_n_clusters(
+    range_n_clusters = get_range_n_clusters(
         100,
         internal_n_clusters=[
             2,
@@ -146,7 +146,7 @@ def test_get_range_n_clusters_with_internal_n_clusters_is_list():
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 25 features
-    range_n_clusters = _get_range_n_clusters(
+    range_n_clusters = get_range_n_clusters(
         25,
         internal_n_clusters=[
             2,
@@ -156,122 +156,122 @@ def test_get_range_n_clusters_with_internal_n_clusters_is_list():
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 25 features
-    range_n_clusters = _get_range_n_clusters(25, internal_n_clusters=[2, 3, 4])
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[2, 3, 4])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 3, 4]))
 
 
 def test_get_range_n_clusters_with_internal_n_clusters_none():
     # 100 features
-    range_n_clusters = _get_range_n_clusters(100, internal_n_clusters=None)
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=None)
     assert range_n_clusters is not None
     np.testing.assert_array_equal(
         range_n_clusters, np.array([2, 3, 4, 5, 6, 7, 8, 9, 10])
     )
 
     # 25 features
-    range_n_clusters = _get_range_n_clusters(25, internal_n_clusters=None)
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=None)
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 3, 4, 5]))
 
 
 def test_get_range_n_clusters_with_internal_n_clusters_has_single_int():
     # 100 features
-    range_n_clusters = _get_range_n_clusters(100, internal_n_clusters=[2])
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=[2])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 25 features
-    range_n_clusters = _get_range_n_clusters(25, internal_n_clusters=[3])
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[3])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([3]))
 
     # 5 features
-    range_n_clusters = _get_range_n_clusters(5, internal_n_clusters=[4])
+    range_n_clusters = get_range_n_clusters(5, internal_n_clusters=[4])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([4]))
 
     # 25 features but invalid number of clusters
-    range_n_clusters = _get_range_n_clusters(25, internal_n_clusters=[1])
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[1])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 
     # 25 features but invalid number of clusters
-    range_n_clusters = _get_range_n_clusters(25, internal_n_clusters=[25])
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[25])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 
 
 def test_get_range_n_clusters_with_internal_n_clusters_are_less_than_two():
     # 100 features
-    range_n_clusters = _get_range_n_clusters(100, internal_n_clusters=[1, 2, 3, 4])
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=[1, 2, 3, 4])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 3, 4]))
 
-    range_n_clusters = _get_range_n_clusters(100, internal_n_clusters=[1, 2, 1, 4])
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=[1, 2, 1, 4])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 4]))
 
-    range_n_clusters = _get_range_n_clusters(100, internal_n_clusters=[1, 2, 3, 1])
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=[1, 2, 3, 1])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 3]))
 
-    range_n_clusters = _get_range_n_clusters(100, internal_n_clusters=[1, 2, 0, 4])
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=[1, 2, 0, 4])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 4]))
 
-    range_n_clusters = _get_range_n_clusters(100, internal_n_clusters=[1, 2, 1, -4, 6])
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=[1, 2, 1, -4, 6])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 6]))
 
 
 def test_get_range_n_clusters_with_internal_n_clusters_are_repeated():
     # 100 features
-    range_n_clusters = _get_range_n_clusters(100, internal_n_clusters=[2, 3, 2, 4])
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=[2, 3, 2, 4])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 3, 4]))
 
-    range_n_clusters = _get_range_n_clusters(100, internal_n_clusters=[2, 2, 2])
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=[2, 2, 2])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
 
 def test_get_range_n_clusters_with_very_few_features():
     # 3 features
-    range_n_clusters = _get_range_n_clusters(3)
+    range_n_clusters = get_range_n_clusters(3)
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 2 features
-    range_n_clusters = _get_range_n_clusters(2)
+    range_n_clusters = get_range_n_clusters(2)
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 
     # 1 features
-    range_n_clusters = _get_range_n_clusters(1)
+    range_n_clusters = get_range_n_clusters(1)
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 
     # 0 features
-    range_n_clusters = _get_range_n_clusters(0)
+    range_n_clusters = get_range_n_clusters(0)
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 
 
 def test_get_range_n_clusters_with_larger_k_than_features():
     # 10 features
-    range_n_clusters = _get_range_n_clusters(10, internal_n_clusters=[10])
+    range_n_clusters = get_range_n_clusters(10, internal_n_clusters=[10])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 
     # 10 features
-    range_n_clusters = _get_range_n_clusters(10, internal_n_clusters=[11])
+    range_n_clusters = get_range_n_clusters(10, internal_n_clusters=[11])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 
 
 def test_get_range_n_clusters_with_default_max_k():
-    range_n_clusters = _get_range_n_clusters(200)
+    range_n_clusters = get_range_n_clusters(200)
     assert range_n_clusters is not None
     np.testing.assert_array_equal(
         range_n_clusters, np.array([2, 3, 4, 5, 6, 7, 8, 9, 10])
@@ -529,12 +529,12 @@ def test_get_parts_simple():
     feature0 = np.random.rand(100)
 
     # run
-    parts = _get_parts(feature0, (2,))
+    parts = get_parts(feature0, (2,))
     assert parts is not None
     assert len(parts) == 1
     assert len(np.unique(parts[0])) == 2
 
-    parts = _get_parts(feature0, (2, 3))
+    parts = get_parts(feature0, (2, 3))
     assert parts is not None
     assert len(parts) == 2
     assert len(np.unique(parts[0])) == 2
@@ -547,12 +547,12 @@ def test_get_parts_with_singletons():
     feature0 = np.array([1.3] * 10)
 
     # run
-    parts = _get_parts(feature0, (2,))
+    parts = get_parts(feature0, (2,))
     assert parts is not None
     assert len(parts) == 1
     np.testing.assert_array_equal(np.unique(parts[0]), np.array([-1]))
 
-    parts = _get_parts(feature0, (2, 3))
+    parts = get_parts(feature0, (2, 3))
     assert parts is not None
     assert len(parts) == 2
     np.testing.assert_array_equal(np.unique(parts[0]), np.array([-1]))

--- a/tests/test_coef.py
+++ b/tests/test_coef.py
@@ -550,12 +550,32 @@ def test_get_parts_with_singletons():
     parts = get_parts(feature0, (2,))
     assert parts is not None
     assert len(parts) == 1
-    np.testing.assert_array_equal(np.unique(parts[0]), np.array([-1]))
+    np.testing.assert_array_equal(np.unique(parts[0]), np.array([-2]))
 
     parts = get_parts(feature0, (2, 3))
     assert parts is not None
     assert len(parts) == 2
-    np.testing.assert_array_equal(np.unique(parts[0]), np.array([-1]))
+    np.testing.assert_array_equal(np.unique(parts[0]), np.array([-2]))
+    np.testing.assert_array_equal(np.unique(parts[1]), np.array([-2]))
+
+
+def test_get_parts_with_categorical_feature():
+    np.random.seed(0)
+
+    feature0 = np.array([4] * 10)
+
+    # run
+    # only one partition is requested
+    parts = get_parts(feature0, (2,), data_is_numerical=False)
+    assert parts is not None
+    assert len(parts) == 1
+    np.testing.assert_array_equal(np.unique(parts[0]), np.array([4]))
+
+    # more partitions are requested; only the first one has valid information
+    parts = get_parts(feature0, (2, 3), data_is_numerical=False)
+    assert parts is not None
+    assert len(parts) == 2
+    np.testing.assert_array_equal(np.unique(parts[0]), np.array([4]))
     np.testing.assert_array_equal(np.unique(parts[1]), np.array([-1]))
 
 

--- a/tests/test_coef.py
+++ b/tests/test_coef.py
@@ -297,7 +297,7 @@ def test_cm_basic():
     cm_value = ccc(feature0, feature1)
     assert cm_value is not None
     assert isinstance(cm_value, float)
-    assert 0.00 < cm_value < 0.02
+    assert cm_value == pytest.approx(0.01, abs=0.01)
 
 
 def test_cm_basic_internal_n_clusters_is_integer():
@@ -369,7 +369,7 @@ def test_cm_random_data():
         cm_value = ccc(feature0, feature1)
 
         # Validate
-        assert 0.0 <= cm_value < 0.05
+        assert cm_value == pytest.approx(0.025, abs=0.025)
 
 
 def test_cm_linear():
@@ -1293,7 +1293,7 @@ def test_cm_numerical_and_categorical_features_strong_relationship():
     cm_value = ccc(numerical_feature0, categorical_feature1)
     assert cm_value is not None
     assert isinstance(cm_value, float)
-    assert 0.30 < cm_value < 0.50
+    assert cm_value == pytest.approx(0.326, abs=0.001)
 
     # flip variables (symmetry)
     assert ccc(categorical_feature1, numerical_feature0) == cm_value
@@ -1320,7 +1320,7 @@ def test_cm_numerical_and_categorical_features_no_relationship():
     cm_value = ccc(numerical_feature0, categorical_feature1)
     assert cm_value is not None
     assert isinstance(cm_value, float)
-    assert 0.00 < cm_value < 0.02
+    assert cm_value == pytest.approx(0.01, abs=0.01)
 
     # flip variables (symmetry)
     assert ccc(categorical_feature1, numerical_feature0) == cm_value

--- a/tests/test_coef.py
+++ b/tests/test_coef.py
@@ -1261,6 +1261,9 @@ def test_cm_numerical_and_categorical_features_perfect_relationship():
     assert isinstance(cm_value, float)
     assert cm_value == 1.0
 
+    # flip variables (symmetry)
+    assert ccc(categorical_feature1, numerical_feature0) == cm_value
+
 
 def test_cm_numerical_and_categorical_features_strong_relationship():
     # Prepare
@@ -1284,6 +1287,9 @@ def test_cm_numerical_and_categorical_features_strong_relationship():
     assert cm_value is not None
     assert isinstance(cm_value, float)
     assert 0.30 < cm_value < 0.50
+
+    # flip variables (symmetry)
+    assert ccc(categorical_feature1, numerical_feature0) == cm_value
 
 
 def test_cm_numerical_and_categorical_features_no_relationship():
@@ -1309,6 +1315,9 @@ def test_cm_numerical_and_categorical_features_no_relationship():
     assert isinstance(cm_value, float)
     assert 0.00 < cm_value < 0.02
 
+    # flip variables (symmetry)
+    assert ccc(categorical_feature1, numerical_feature0) == cm_value
+
 
 def test_cm_numerical_and_categorical_features_too_many_categories():
     # Prepare
@@ -1331,6 +1340,9 @@ def test_cm_numerical_and_categorical_features_too_many_categories():
     assert isinstance(cm_value, float)
     assert cm_value == 0.0
 
+    # flip variables (symmetry)
+    assert ccc(categorical_feature1, numerical_feature0) == cm_value
+
 
 def test_cm_numerical_and_categorical_features_a_single_categorical_value():
     # Prepare
@@ -1350,6 +1362,9 @@ def test_cm_numerical_and_categorical_features_a_single_categorical_value():
     assert cm_value is not None
     assert isinstance(cm_value, float)
     assert cm_value == 0.0
+
+    # flip variables (symmetry)
+    assert ccc(categorical_feature1, numerical_feature0) == cm_value
 
 
 def test_cm_numerical_and_categorical_features_with_pandas_dataframe_two_features():
@@ -1381,6 +1396,9 @@ def test_cm_numerical_and_categorical_features_with_pandas_dataframe_two_feature
     assert cm_value is not None
     assert isinstance(cm_value, float)
     assert cm_value == 1.0
+
+    # flip variables (symmetry)
+    assert ccc(data.iloc[:, [1, 0]]) == cm_value
 
 
 def test_cm_with_pandas_dataframe_several_features():

--- a/tests/test_coef.py
+++ b/tests/test_coef.py
@@ -3,10 +3,9 @@ from random import shuffle
 
 import numpy as np
 import pandas as pd
-from numba.typed import List
+import pytest
 from sklearn.preprocessing import minmax_scale
 from sklearn.metrics import adjusted_rand_score as ari
-import pytest
 
 from ccc.coef import (
     ccc,
@@ -139,7 +138,7 @@ def test_get_range_n_clusters_with_internal_n_clusters_is_list():
     # 100 features
     range_n_clusters = get_range_n_clusters(
         100,
-        internal_n_clusters=List([2]),
+        internal_n_clusters=[2],
     )
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
@@ -147,13 +146,13 @@ def test_get_range_n_clusters_with_internal_n_clusters_is_list():
     # 25 features
     range_n_clusters = get_range_n_clusters(
         25,
-        internal_n_clusters=List([2]),
+        internal_n_clusters=[2],
     )
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 25 features
-    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=List([2, 3, 4]))
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[2, 3, 4])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2, 3, 4]))
 
@@ -174,27 +173,27 @@ def test_get_range_n_clusters_with_internal_n_clusters_none():
 
 def test_get_range_n_clusters_with_internal_n_clusters_has_single_int():
     # 100 features
-    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=List([2]))
+    range_n_clusters = get_range_n_clusters(100, internal_n_clusters=[2])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([2]))
 
     # 25 features
-    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=List([3]))
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[3])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([3]))
 
     # 5 features
-    range_n_clusters = get_range_n_clusters(5, internal_n_clusters=List([4]))
+    range_n_clusters = get_range_n_clusters(5, internal_n_clusters=[4])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([4]))
 
     # 25 features but invalid number of clusters
-    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=List([1]))
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[1])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 
     # 25 features but invalid number of clusters
-    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=List([25]))
+    range_n_clusters = get_range_n_clusters(25, internal_n_clusters=[25])
     assert range_n_clusters is not None
     np.testing.assert_array_equal(range_n_clusters, np.array([]))
 

--- a/tests/test_giant.py
+++ b/tests/test_giant.py
@@ -1,5 +1,13 @@
+import sys
+
 import pandas as pd
 import pytest
+
+if not sys.platform.startswith("linux"):
+    # it's not necessary to test the REST API against GIANT in all platforms
+    pytest.skip(
+        "Skipping REST test on GIANT in non-Linux systems", allow_module_level=True
+    )
 
 from ccc.giant import gene_exists, predict_tissue, get_network
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 """
-Tests the utils.py module.
+Tests the utility_functions.py module.
 """
 from unittest.mock import MagicMock
 from pathlib import Path


### PR DESCRIPTION
This PR adds support for categorical values as input for CCC. It can also handle pandas DataFrames in addition to numpy arrays.