### PR TITLE
Add setup.py to create PyPI package ccc-coef

### DIFF
--- a/libs/ccc/__init__.py
+++ b/libs/ccc/__init__.py
@@ -1,0 +1,2 @@
+# Remember to change also pyproject.toml with the version here
+__version__ = "0.1.5"

--- a/libs/ccc/__init__.py
+++ b/libs/ccc/__init__.py
@@ -1,2 +1,2 @@
-# Remember to change also pyproject.toml with the version here
+# Remember to change also setup.py with the version here
 __version__ = "0.1.5"

--- a/libs/ccc/coef/__init__.py
+++ b/libs/ccc/coef/__init__.py
@@ -2,6 +2,9 @@ from ccc.coef.impl import *  # noqa: F403, F401
 
 try:
     # Run CCC to initialize/compile its functions with numba
+    from ccc.coef.impl import ccc
+    import numpy as np
+
     ccc(np.random.rand(10), np.random.rand(10))
 except Exception as e:
     raise e

--- a/libs/ccc/coef/__init__.py
+++ b/libs/ccc/coef/__init__.py
@@ -1,10 +1,7 @@
 from ccc.coef.impl import *  # noqa: F403, F401
 
-try:
-    # Run CCC to initialize/compile its functions with numba
-    from ccc.coef.impl import ccc
-    import numpy as np
+# Run CCC to initialize/compile its functions with numba
+from ccc.coef.impl import ccc
+import numpy as np
 
-    ccc(np.random.rand(10), np.random.rand(10))
-except Exception as e:
-    raise e
+ccc(np.random.rand(10), np.random.rand(10))

--- a/libs/ccc/coef/__init__.py
+++ b/libs/ccc/coef/__init__.py
@@ -1,1 +1,7 @@
 from ccc.coef.impl import *  # noqa: F403, F401
+
+try:
+    # Run CCC to initialize/compile its functions with numba
+    ccc(np.random.rand(10), np.random.rand(10))
+except Exception as e:
+    raise e

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
 import setuptools
 
+# Commands to publish new package:
+#
+# rm -rf dist/
+# python setup.py sdist
+# twine upload dist/*
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="ccc-coef",
+    version="0.1.5",  # remember to change libs/ccc/__init__.py file also
+    author="Milton Pividori",
+    author_email="miltondp@gmail.com",
+    description="The Clustermatch Correlation Coefficient (CCC) is a highly-efficient, next-generation not-only-linear correlation coefficient that can work on numerical and categorical data types.",
+    license="BSD-2-Clause Plus Patent",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/greenelab/ccc",
+    package_dir={"": "libs"},
+    packages=[
+        "ccc/coef",
+        "ccc/numpy",
+        "ccc/pytorch",
+        "ccc/scipy",
+        "ccc/sklearn",
+        "ccc/utils",
+    ],
+    python_requires=">=3.9",
+    install_requires=[
+        "numpy",
+        "scipy",
+        "numba",
+    ],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+    ],
+)


### PR DESCRIPTION
This PR adds the file `setup.py` to create the `ccc-coef` PyPI package with CCC. The package is already published [here](https://pypi.org/project/ccc-coef/).

In addition to review the code, the reviewer is asked to also test it to see if it works in his/her machine. With conda, the commands to test it would be:

```bash
conda create -y -n ccc-test python=3 ipython
conda activate ccc-test
pip install ccc-coef
```

Then run `ipython` and execute these commands (I'm showing the output I get as a reference), and paste the output you get as a comment here:

```python
In [1]: from ccc.coef import ccc

In [2]: import numpy as np

In [3]: ccc(np.random.rand(100), np.random.rand(100))
Out[3]: 0.04859557105443353

In [4]: data = np.random.rand(10, 1000)

In [5]: ccc(data)
Out[5]: 
array([0.00195757, 0.00182925, 0.00206961, 0.0035724 , 0.00082191,
       0.00606107, 0.00163949, 0.0022531 , 0.00522882, 0.00470232,
       0.00345744, 0.00619745, 0.00320236, 0.00222106, 0.00244171,
       0.00290764, 0.00134852, 0.00265877, 0.0036212 , 0.00264046,
       0.00300241, 0.00446371, 0.00542057, 0.00223036, 0.00054122,
       0.00134977, 0.00238008, 0.00333387, 0.00311286, 0.00253637,
       0.0032342 , 0.00269911, 0.0011746 , 0.00272789, 0.00432598,
       0.00165459, 0.00546475, 0.00418719, 0.00041738, 0.00282826,
       0.00369037, 0.00489086, 0.00284981, 0.00285645, 0.00247363])

In [6]: %timeit ccc(data, n_jobs=1)
282 ms ± 13.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [7]: %timeit ccc(data, n_jobs=2)
170 ms ± 1.34 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [8]: 
```