### PR TITLE
Add a workflow to test CCC under Python 3.9 and 3.10 across all operating systems

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest numpy scipy numba pandas==1.4* sklearn==1.1.
+          pip install pytest numpy scipy numba pandas==1.4.* sklearn==1.1.*
       - name: Test CCC with pytest
         env:
           PYTHONPATH: libs/

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest numpy scipy numba pandas==1.4.* sklearn==1.1.*
+          pip install pytest numpy scipy numba pandas==1.4.* scikit-learn==1.1.*
       - name: Test CCC with pytest
         env:
           PYTHONPATH: libs/

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,8 +29,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest numpy scipy numba
+          pip install pytest numpy scipy numba pandas==1.4* sklearn==1.1.
       - name: Test CCC with pytest
+        env:
+          PYTHONPATH: libs/
         run: |
           pytest tests/test_coef.py tests/test_pytorch_core.py tests/test_scipy_stats.py tests/test_sklearn_metrics.py tests/test_utils.py
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -17,7 +17,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.10]
+        python-version: ["3.9", "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - name: Checkout git repo
@@ -43,7 +43,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ["3.9"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - name: Checkout git repo

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -34,7 +34,7 @@ jobs:
         env:
           PYTHONPATH: libs/
         run: |
-          pytest tests/test_coef.py tests/test_pytorch_core.py tests/test_scipy_stats.py tests/test_sklearn_metrics.py tests/test_utils.py
+          pytest tests/test_coef.py tests/test_pytorch_core.py tests/test_scipy_stats.py tests/test_sklearn_metrics.py
 
   pytest:
     name: Python tests on code for analyses

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -7,11 +7,35 @@ on:
 env:
   # Increase this value to reset cache if environment.yml has not changed.
   PY_CACHE_NUMBER: 2
-  PY_ENV: cm_gene_expr
+  PY_ENV: ccc_gene_expr
 
 jobs:
+  ccc_pytest:
+    name: Python tests for CCC
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      fail-fast: false
+      matrix:
+        python-version: [3.9, 3.10]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest numpy scipy numba
+      - name: Test CCC with pytest
+        run: |
+          pytest tests/test_coef.py tests/test_pytorch_core.py tests/test_scipy_stats.py tests/test_sklearn_metrics.py tests/test_utils.py
+
   pytest:
-    name: Python tests
+    name: Python tests on code for analyses
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4
@@ -21,9 +45,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - name: Checkout git repo
-        uses: actions/checkout@v2
-        with:
-          lfs: false
+        uses: actions/checkout@v3
       - name: Cache conda
         id: cache
         uses: actions/cache@v3

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,7 +37,7 @@ jobs:
           pytest tests/test_coef.py tests/test_pytorch_core.py tests/test_scipy_stats.py tests/test_sklearn_metrics.py
 
   pytest:
-    name: Python tests on code for analyses
+    name: Python tests for analyses
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 4


### PR DESCRIPTION
This is a very small PR that adds another workflow in Github Actions to specifically test CCC on Python 3.9 and 3.10 across Linux, macOS and Windows. The idea is to keep adding new versions of Python to make sure CCC works on them.