### PR TITLE
Fix dependencies and require numpy>=1.21

### DIFF
--- a/libs/ccc/__init__.py
+++ b/libs/ccc/__init__.py
@@ -1,2 +1,2 @@
 # Remember to change also setup.py with the version here
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ccc-coef",
-    version="0.1.6",  # remember to change libs/ccc/__init__.py file also
+    version="0.1.7",  # remember to change libs/ccc/__init__.py file also
     author="Milton Pividori",
     author_email="miltondp@gmail.com",
     description="The Clustermatch Correlation Coefficient (CCC) is a highly-efficient, next-generation not-only-linear correlation coefficient that can work on numerical and categorical data types.",
@@ -30,7 +30,8 @@ setuptools.setup(
     ],
     python_requires=">=3.9",
     install_requires=[
-        "numpy",
+        # numpy.typing is only available in numpy>=1.21.0
+        "numpy>=1.21.0",
         "scipy",
         "numba",
     ],


### PR DESCRIPTION
This fixes issue #28 by explicitely requiring `numpy>=1.21.0`

## Steps to reproduce issue #28 

This installs ccc-coef version 0.1.6)

```bash
conda create -n ccc-fix-issue-28 python=3 numpy=1.20 numba=0.53 scipy=1.7
conda activate ccc-fix-issue-28
pip install ccc-coef

# try to import ccc function
python -c "from ccc.coef import ccc"
```

This should produce this error:
```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/miltondp/software/miniconda3/envs/ccc-fix-issue-28/lib/python3.9/site-packages/ccc/coef/__init__.py", line 1, in <module>
    from ccc.coef.impl import *  # noqa: F403, F401
  File "/home/miltondp/software/miniconda3/envs/ccc-fix-issue-28/lib/python3.9/site-packages/ccc/coef/impl.py", line 9, in <module>
    from numpy.typing import NDArray
ImportError: cannot import name 'NDArray' from 'numpy.typing' (/home/miltondp/software/miniconda3/envs/ccc-fix-issue-28/lib/python3.9/site-packages/numpy/typing/__init__.py)
```

## Steps to fix by installing `numpy>=1.21`

```bash
conda create -n ccc-fix-issue-28-2 python=3 numpy=1.21 numba=0.53 scipy=1.7
conda activate ccc-fix-issue-28-2
pip install ccc-coef

# try to import ccc function
python -c "from ccc.coef import ccc"
```

No error should appear.

## Steps to test new version

```bash
# get latest code
git clone -b fix.issue.28 git@github.com:greenelab/ccc.git

# here I force to use an old version of nuompy
conda create -n ccc-fix-issue-28-3 python=3 numpy=1.20 numba=0.53 scipy=1.7
conda activate ccc-fix-issue-28-3
cd ccc/
pip install -e .

# try to import ccc function
python -c "from ccc.coef import ccc"
```

No error should appear.