### PR TITLE
Fix the calculation for the number of threads to be used

### DIFF
--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -523,6 +523,8 @@ def get_n_workers(n_jobs: int | None) -> int:
 
     Args:
         n_jobs: value specified by the main ccc function.
+    Returns:
+        The number of workers to use for parallel processing
     """
     n_cpu_cores = os.cpu_count()
     if n_cpu_cores is None:

--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -623,8 +623,8 @@ def ccc(
     X_numerical_type = None
     if x.ndim == 1 and (y is not None and y.ndim == 1):
         # both x and y are 1d arrays
-        # TODO: remove assertions and raise exceptions
-        assert x.shape == y.shape, "x and y need to be of the same size"
+        if not x.shape == y.shape:
+            raise ValueError("x and y need to be of the same size")
         n_objects = x.shape[0]
         n_features = 2
 
@@ -640,10 +640,9 @@ def ccc(
         # plus we have the features data type (numerical, categorical, etc)
 
         if isinstance(x, np.ndarray):
-            assert get_feature_type_and_encode(x[0, :])[1], (
-                "If data is a 2d numpy array, it has to be numerical. Use pandas.DataFrame if "
-                "you need to mix features with different data types"
-            )
+            if not get_feature_type_and_encode(x[0, :])[1]:
+                raise ValueError("If data is a 2d numpy array, it has to be numerical. Use pandas.DataFrame if "
+                                 "you need to mix features with different data types")
             n_objects = x.shape[1]
             n_features = x.shape[0]
 

--- a/libs/ccc/coef/impl.py
+++ b/libs/ccc/coef/impl.py
@@ -640,7 +640,7 @@ def ccc(
 
     # get number of cores to use
     n_jobs = os.cpu_count() if n_jobs is None else n_jobs
-    default_n_threads = (os.cpu_count() - n_jobs) if n_jobs < 0 else n_jobs
+    default_n_threads = (os.cpu_count() + n_jobs) if n_jobs < 0 else n_jobs
 
     if internal_n_clusters is not None:
         _tmp_list = List()


### PR DESCRIPTION
There's a bug when n_jobs is provided as a negative number. Here's the original contract and code:

Docstring:
n_jobs: number of CPU cores to use for parallelization. The value
          None will use all available cores (`os.cpu_count()`), and negative
          values will use `os.cpu_count() - n_jobs`. Default is 1.

Code:
```
# get the number of cores to use
n_jobs = os.cpu_count() if n_jobs is None else n_jobs
default_n_threads = (os.cpu_count() - n_jobs) if n_jobs < 0 else n_jobs
```

It's clear that we should fix the subtraction to an addition:
```
default_n_threads = (os.cpu_count() + n_jobs) if n_jobs < 0 else n_jobs
```